### PR TITLE
src/thesiaslib.c: fix implicit declaration of thesiasRun.

### DIFF
--- a/src/thesiaslib.c
+++ b/src/thesiaslib.c
@@ -26,6 +26,7 @@ extern double ndtri (double);
 extern double gamma (double);
 extern double chdtrc(double, double);
 extern int mtherr(char *, int );
+extern int thesiasRun(char*, int, int, int*, int, int, int, int, int, int, int, int, int, int*, int, int);
 
 JNIEXPORT jint JNICALL Java_thesiaslib_thesiasRun
   (JNIEnv      *env, 


### PR DESCRIPTION
The definition in src/thesiaslib.h does not seem to be properly captured.  This is a band aid to avoid triping zealous compiler options.

Remark, the initial patch in Debian had to be complemented because a couple of integer arrays were not properly reflected in the extern function declaration.